### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: ruby
+arch:
+  - amd64
+  - ppc64le
 before_install: gem install bundler
 cache: bundler
 rvm:
@@ -10,3 +13,7 @@ rvm:
 jobs:
   allow_failures:
     - rvm: ruby-head
+# ppc64le support code
+    - rvm: ruby-head
+      arch: ppc64le
+      


### PR DESCRIPTION
This PR adds CI support for the IBM Power Little Endian (ppc64le) architecture. The idea is to ensure that the builds on this architecture are continuously tested along with the Intel builds (amd64) as this is part of the ubuntu distro on that architecture as well and detecting (and fixing) any issues or failures early would help to ensure that we are always up to date.
The build and test results are available at the below location.
https://travis-ci.com/github/nageshlop/declarative